### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Elm Columns [![Netlify Status](https://api.netlify.com/api/v1/badges/790abe46-307d-414a-a863-2c00991e960f/deploy-status)](https://app.netlify.com/sites/elm-columns/deploys)
-
+# Elm Columns [![Netlify Status](https://api.netlify.com/api/v1/badges/790abe46-307d-414a-a863-2c00991e960f/deploy-status)](https://app.netlify.com/sites/elm-columns/deploys) [![Run on Repl.it](https://repl.it/badge/github/TechnoTone/elm-columns)](https://repl.it/github/TechnoTone/elm-columns)
 
 A simple Columns game written in [Elm](https://elm-lang.org).
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).